### PR TITLE
Small fixes to tf-record plugin

### DIFF
--- a/rmldatatfrecord/setup.py
+++ b/rmldatatfrecord/setup.py
@@ -16,6 +16,7 @@ setup(
         'opencv-python',
         'numpy',
         'tensorflow',
+        'tqdm',
     ],
     entry_points='''
         [ravenml.plugins.data]


### PR DESCRIPTION
Removes the contextlib2 dependency, allows for some leeway in the check for 3D keypoint equivalences, and adds a progress bar via tqdm to the dataset object creation.