### PR TITLE
Git Info Logging for rmldatatfrecord

### DIFF
--- a/rmldatatfrecord/setup.py
+++ b/rmldatatfrecord/setup.py
@@ -1,7 +1,8 @@
 from setuptools import setup, find_packages
-from os import path, remove
+from os import remove
 from json import dump
 from shutil import copyfile
+from pathlib import Path
 from ravenml.utils.git import is_repo, git_sha, git_patch_tracked, git_patch_untracked
 
 # figured out to use find_packages() via:
@@ -11,7 +12,7 @@ from ravenml.utils.git import is_repo, git_sha, git_patch_tracked, git_patch_unt
 # gpu = os.getenv('RML_BBOX_GPU')
 # tensorflow_pkg = 'tensorflow==1.14.0' if not gpu else 'tensorflow-gpu==1.14.0'
 
-plugin_dir = path.abspath(path.dirname(__file__))
+plugin_dir = Path(__file__).resolve().parent
 
 # attempt to write git data to file
 # this will work in 3/4 install cases:
@@ -27,7 +28,7 @@ if repo:
         'plugin_tracked_git_patch': git_patch_tracked(plugin_dir),
         'plugin_untracked_git_patch': git_patch_untracked(plugin_dir)
     }
-    with open(path.join(plugin_dir, 'rmldatatfrecord', 'git_info.json'), 'w') as f:
+    with open(plugin_dir / 'rmldatatfrecord' / 'git_info.json', 'w') as f:
         dump(info, f, indent=2)
 
 setup(
@@ -55,4 +56,4 @@ setup(
 # the file from corrupting the git repo, and when creating a dist for PyPI 
 # for the same reason.
 if repo:
-    remove(path.join(plugin_dir, 'rmldatatfrecord', 'git_info.json'))
+    remove(plugin_dir / 'rmldatatfrecord' / 'git_info.json')

--- a/rmldatatfrecord/setup.py
+++ b/rmldatatfrecord/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup, find_packages
 from os import remove
 from json import dump
-from shutil import copyfile
 from pathlib import Path
 from ravenml.utils.git import is_repo, git_sha, git_patch_tracked, git_patch_untracked
 

--- a/rmldatatfrecord/setup.py
+++ b/rmldatatfrecord/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=[
         'opencv-python',
         'numpy<1.19',
-        'tensorflow>=2.3',
+        'tensorflow~=2.3.0',
         'tqdm',
     ],
     entry_points=f'''

--- a/rmldatatfrecord/setup.py
+++ b/rmldatatfrecord/setup.py
@@ -1,4 +1,8 @@
 from setuptools import setup, find_packages
+from os import path, remove
+from json import dump
+from shutil import copyfile
+from ravenml.utils.git import is_repo, git_sha, git_patch_tracked, git_patch_untracked
 
 # figured out to use find_packages() via:
 # https://stackoverflow.com/questions/10924885/is-it-possible-to-include-subdirectories-using-dist-utils-setup-py-as-part-of
@@ -7,15 +11,36 @@ from setuptools import setup, find_packages
 # gpu = os.getenv('RML_BBOX_GPU')
 # tensorflow_pkg = 'tensorflow==1.14.0' if not gpu else 'tensorflow-gpu==1.14.0'
 
+plugin_dir = path.abspath(path.dirname(__file__))
+
+# attempt to write git data to file
+# this will work in 3/4 install cases:
+#   1. PyPI
+#   2. GitHub clone
+#   3. Local (editable), NOTE in this case there is no need
+#       for the file, as ravenml will find git information at runtime
+# NOTE: does NOT work in the GitHub tarball installation case
+repo = is_repo(plugin_dir)
+if repo:
+    info = {
+        'plugin_git_sha': git_sha(plugin_dir),
+        'plugin_tracked_git_patch': git_patch_tracked(plugin_dir),
+        'plugin_untracked_git_patch': git_patch_untracked(plugin_dir)
+    }
+    with open(path.join(plugin_dir, 'rmldatatfrecord', 'git_info.json'), 'w') as f:
+        dump(info, f, indent=2)
+
 setup(
     name='rmldatatfrecord',
     version='0.1',
     description='Dataset creation plugin for ravenML',
     packages=find_packages(),
+    package_data={'rmldatatfrecord': ['git_info.json']},
+    setup_requires=['ravenml'],
     install_requires=[
         'opencv-python',
-        'numpy',
-        'tensorflow',
+        'numpy<1.19',
+        'tensorflow>=2.3',
         'tqdm',
     ],
     entry_points='''
@@ -23,3 +48,11 @@ setup(
         tf_record=rmldatatfrecord.core:tf_record
     '''
 )
+
+# destroy git file after install
+# NOTE: this is pointless for GitHub clone case, since the clone is deleted
+# after install. It is necessary for local (editable) installs to prevent
+# the file from corrupting the git repo, and when creating a dist for PyPI 
+# for the same reason.
+if repo:
+    remove(path.join(plugin_dir, 'rmldatatfrecord', 'git_info.json'))


### PR DESCRIPTION
Adds necessary `setup.py` logic to store git information into `git_info.json` at install time so it is available to inject into metadata at runtime when this plugin is used to create datasets.