### PR TITLE
Add Filtering Methods and rename to rmldatatfrecord

### DIFF
--- a/rmldatatfbbox/rmldatatfbbox/core.py
+++ b/rmldatatfbbox/rmldatatfbbox/core.py
@@ -49,8 +49,11 @@ def tf_bbox(ctx, create: CreateInput):
 
     datasetWriter.load_image_ids(metadata_format)
 
-    if config.get('filter'):
-        datasetWriter.interactive_filter()
+    # Filtering
+    if config.get('setSizeFilter'):
+        datasetWriter.set_size_filter(config['setSizeFilter'])
+    if config.get('tagFilter'):
+        datasetWriter.interactive_tag_filter()
             
     datasetWriter.construct_all()
 

--- a/rmldatatfbbox/sample_configs/bbox_all_fields.yaml
+++ b/rmldatatfbbox/sample_configs/bbox_all_fields.yaml
@@ -4,6 +4,7 @@
 dataset_name: bbox_test_dataset
 # local: False
 imageset: # If local, then full paths to each local imageset
+  # - cygnus_1k_random
   - jigsaw_tester
 overwrite_local: True
 # dataset_path: '~/Desktop/test' # Default: ~/.ravenML/data_tf-bbox/datasets
@@ -16,4 +17,7 @@ metadata:
     comments: test
 plugin:
     verbose: True
-    # filter: False
+    # tagFilter: False
+    # setSizeFilter:
+      # cygnus_1k_random: 100
+      # jigsaw_tester: 4

--- a/rmldatatfrecord/sample_configs/tf_record_all_fields.yaml
+++ b/rmldatatfrecord/sample_configs/tf_record_all_fields.yaml
@@ -1,4 +1,4 @@
-# This sample config contains all fields supported by ravenML core and the bbox plugin.
+# This sample config contains all fields supported by ravenML core and the TFRecord plugin.
 # Plugin specific configuration is located in the plugin field.
 
 dataset_name: bbox_test_dataset

--- a/rmldatatfrecord/setup.py
+++ b/rmldatatfrecord/setup.py
@@ -1,7 +1,8 @@
 from setuptools import setup, find_packages
-from os import path, remove
+from os import remove
 from json import dump
 from shutil import copyfile
+from pathlib import Path
 from ravenml.utils.git import is_repo, git_sha, git_patch_tracked, git_patch_untracked
 
 # figured out to use find_packages() via:
@@ -11,7 +12,7 @@ from ravenml.utils.git import is_repo, git_sha, git_patch_tracked, git_patch_unt
 # gpu = os.getenv('RML_BBOX_GPU')
 # tensorflow_pkg = 'tensorflow==1.14.0' if not gpu else 'tensorflow-gpu==1.14.0'
 
-plugin_dir = path.abspath(path.dirname(__file__))
+plugin_dir = Path(__file__).resolve().parent
 
 # attempt to write git data to file
 # this will work in 3/4 install cases:
@@ -27,7 +28,7 @@ if repo:
         'plugin_tracked_git_patch': git_patch_tracked(plugin_dir),
         'plugin_untracked_git_patch': git_patch_untracked(plugin_dir)
     }
-    with open(path.join(plugin_dir, 'rmldatatfrecord', 'git_info.json'), 'w') as f:
+    with open(plugin_dir / 'rmldatatfrecord' / 'git_info.json', 'w') as f:
         dump(info, f, indent=2)
 
 setup(
@@ -55,4 +56,4 @@ setup(
 # the file from corrupting the git repo, and when creating a dist for PyPI 
 # for the same reason.
 if repo:
-    remove(path.join(plugin_dir, 'rmldatatfrecord', 'git_info.json'))
+    remove(plugin_dir / 'rmldatatfrecord' / 'git_info.json')

--- a/rmldatatfrecord/setup.py
+++ b/rmldatatfrecord/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup, find_packages
 from os import remove
 from json import dump
-from shutil import copyfile
 from pathlib import Path
 from ravenml.utils.git import is_repo, git_sha, git_patch_tracked, git_patch_untracked
 

--- a/rmldatatfrecord/setup.py
+++ b/rmldatatfrecord/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=[
         'opencv-python',
         'numpy<1.19',
-        'tensorflow>=2.3',
+        'tensorflow~=2.3.0',
         'tqdm',
     ],
     entry_points=f'''

--- a/rmldatatfrecord/setup.py
+++ b/rmldatatfrecord/setup.py
@@ -1,4 +1,8 @@
 from setuptools import setup, find_packages
+from os import path, remove
+from json import dump
+from shutil import copyfile
+from ravenml.utils.git import is_repo, git_sha, git_patch_tracked, git_patch_untracked
 
 # figured out to use find_packages() via:
 # https://stackoverflow.com/questions/10924885/is-it-possible-to-include-subdirectories-using-dist-utils-setup-py-as-part-of
@@ -7,15 +11,36 @@ from setuptools import setup, find_packages
 # gpu = os.getenv('RML_BBOX_GPU')
 # tensorflow_pkg = 'tensorflow==1.14.0' if not gpu else 'tensorflow-gpu==1.14.0'
 
+plugin_dir = path.abspath(path.dirname(__file__))
+
+# attempt to write git data to file
+# this will work in 3/4 install cases:
+#   1. PyPI
+#   2. GitHub clone
+#   3. Local (editable), NOTE in this case there is no need
+#       for the file, as ravenml will find git information at runtime
+# NOTE: does NOT work in the GitHub tarball installation case
+repo = is_repo(plugin_dir)
+if repo:
+    info = {
+        'plugin_git_sha': git_sha(plugin_dir),
+        'plugin_tracked_git_patch': git_patch_tracked(plugin_dir),
+        'plugin_untracked_git_patch': git_patch_untracked(plugin_dir)
+    }
+    with open(path.join(plugin_dir, 'rmldatatfrecord', 'git_info.json'), 'w') as f:
+        dump(info, f, indent=2)
+
 setup(
     name='rmldatatfrecord',
     version='0.1',
     description='Dataset creation plugin for ravenML',
     packages=find_packages(),
+    package_data={'rmldatatfrecord': ['git_info.json']},
+    setup_requires=['ravenml'],
     install_requires=[
         'opencv-python',
-        'numpy',
-        'tensorflow',
+        'numpy<1.19',
+        'tensorflow>=2.3',
         'tqdm',
     ],
     entry_points='''
@@ -23,3 +48,11 @@ setup(
         tf_record=rmldatatfrecord.core:tf_record
     '''
 )
+
+# destroy git file after install
+# NOTE: this is pointless for GitHub clone case, since the clone is deleted
+# after install. It is necessary for local (editable) installs to prevent
+# the file from corrupting the git repo, and when creating a dist for PyPI 
+# for the same reason.
+if repo:
+    remove(path.join(plugin_dir, 'rmldatatfrecord', 'git_info.json'))


### PR DESCRIPTION
Replaces #2. Injects filtering functionality into the rmldatatfrecord package. Necessary because #2 was targeted at the old rmldatatfbbox plugin before it was renamed.